### PR TITLE
[remove-too-strict-rules] Remove some strict rules that were not enabled on purpose

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -55,11 +55,11 @@ module.exports = {
     //'scss/double-slash-comment-whitespace-inside': 'never',
 
     // Declaration
-    'scss/declaration-nested-properties': 'never',
+    //'scss/declaration-nested-properties': 'never',
     'scss/declaration-nested-properties-no-divided-groups': true,
 
     // Media feature
-    'scss/media-feature-value-dollar-variable': 'always',
+    // 'scss/media-feature-value-dollar-variable': 'always',
 
     // Operator
     'scss/operator-no-newline-after': true,


### PR DESCRIPTION
This PR fixes https://app.asana.com/0/867134676478714/1110560689163501
and enables the nested css properties feature:
https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/declaration-nested-properties
https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/declaration-nested-properties-no-divided-groups